### PR TITLE
Add a link to the actual website on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Data Rescue SF Bay
+
+Code for the website: [http://datarescuesfbay.org/](http://datarescuesfbay.org/)
+
+---
 
 This is forked from [github.com/t413/SinglePaged](https://github.com/t413/SinglePaged)
 


### PR DESCRIPTION
This will make it easier to get to the actual website if one has only
found the GitHub README.